### PR TITLE
avoid creating unused results arrays

### DIFF
--- a/source/Heap.coffee
+++ b/source/Heap.coffee
@@ -59,6 +59,7 @@ class Heap
             [@_data[index], @_data[_parent index]] =
             [@_data[_parent index], @_data[index]]
             index = _parent index
+        null
 
     _downHeap: ->
         currentIndex = 1
@@ -74,6 +75,7 @@ class Heap
                 currentIndex = smallerChildIndex
             else
                 break
+        null
 
 _parent = (index) -> index >> 1 # Fast divide by 2 then flooring.
 


### PR DESCRIPTION
iterators in Coffeescript will create result arrays (check JS source to see them) if they're the last expression in a function. added return nulls here to avoid them
