### PR TITLE
call hasOwnProperty() on nodes to ignore properties or functions defined on Object

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -19,10 +19,19 @@ module.exports = (grunt) ->
         dest: 'distribution/'
         ext: '.js'
 
-    exec:
-      test:
-        cmd:
-          './node_modules/.bin/jasmine-node --coffee --test-dir tests --verbose'
+    jasmine_node:
+        projectRoot: '.'
+        source: './source'
+        specFolders: [ './tests' ]
+        specNameMatcher: 'spec'
+        extensions: 'coffee'
+        useCoffee: true
+        forceExit: false
+        jUnit:
+            report: false
+            savePath: './reports/jasmine/'
+            useDotNotation: true
+            consolidate: true
 
     browserify2:
       compile:
@@ -42,9 +51,9 @@ module.exports = (grunt) ->
   grunt.loadNpmTasks 'grunt-contrib-coffee'
   grunt.loadNpmTasks 'grunt-browserify2'
   grunt.loadNpmTasks 'grunt-contrib-uglify'
-  grunt.loadNpmTasks 'grunt-exec'
+  grunt.loadNpmTasks 'grunt-jasmine-node'
 
-  grunt.registerTask 'test', [ 'exec:test' ]
+  grunt.registerTask 'test', [ 'jasmine_node' ]
 
   grunt.registerTask 'default', ['coffeelint', 'clean', 'coffee',
                                  'test', 'browserify2', 'uglify']

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -19,6 +19,11 @@ module.exports = (grunt) ->
         dest: 'distribution/'
         ext: '.js'
 
+    exec:
+      test:
+        cmd:
+          './node_modules/.bin/jasmine-node --coffee --test-dir tests --verbose'
+
     browserify2:
       compile:
         options:
@@ -37,6 +42,9 @@ module.exports = (grunt) ->
   grunt.loadNpmTasks 'grunt-contrib-coffee'
   grunt.loadNpmTasks 'grunt-browserify2'
   grunt.loadNpmTasks 'grunt-contrib-uglify'
+  grunt.loadNpmTasks 'grunt-exec'
+
+  grunt.registerTask 'test', [ 'exec:test' ]
 
   grunt.registerTask 'default', ['coffeelint', 'clean', 'coffee',
-                                 'browserify2', 'uglify']
+                                 'test', 'browserify2', 'uglify']

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "grunt-browserify2": "~0.1.7",
     "grunt-contrib-uglify": "~0.2.0",
     "grunt-coffeelint": "0.0.6",
-    "grunt-exec": "~0.4.2"
+    "grunt-jasmine-node": "~0.1.0"
   },
   "engines": {
     "node": "*"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "grunt-contrib-coffee": "~0.7.0",
     "grunt-browserify2": "~0.1.7",
     "grunt-contrib-uglify": "~0.2.0",
-    "grunt-coffeelint": "0.0.6"
+    "grunt-coffeelint": "0.0.6",
+    "grunt-exec": "~0.4.2"
   },
   "engines": {
     "node": "*"

--- a/source/Trie.coffee
+++ b/source/Trie.coffee
@@ -138,7 +138,7 @@ class Trie
       [node, accumulatedLetters] = queue.dequeue()
       if node[WORD_END]
         words.push prefix + accumulatedLetters
-      for letter, subNode of node
+      for own letter, subNode of node
         queue.enqueue [subNode, accumulatedLetters + letter]
     return words
 
@@ -175,7 +175,7 @@ class Trie
 _hasAtLeastNChildren = (node, n) ->
   return yes if n is 0
   childCount = 0
-  for child of node
+  for own child of node
     childCount++
     return yes if childCount >= n
   return no

--- a/tests/Map.spec.coffee
+++ b/tests/Map.spec.coffee
@@ -33,9 +33,9 @@ describe "Hash function", ->
     expect(map.hash obj, yes).toMatch /_mapId_\d+_\d+/
     expect(map.hash date, yes).toMatch /_mapId_\d+_\d+/
   it "should have used obscure hacks by putting an id in arr and obj", ->
-    expect(arr._mapId_2).toEqual any Number
-    expect(obj._mapId_2).toEqual any Number
-    expect(date._mapId_2).toEqual any Number
+    expect(arr._mapId_2).toEqual jasmine.any Number
+    expect(obj._mapId_2).toEqual jasmine.any Number
+    expect(date._mapId_2).toEqual jasmine.any Number
 
 describe "Set and get/has", ->
   map = new Map()
@@ -211,4 +211,4 @@ describe "Iterate through items", ->
     expect(callback).toHaveBeenCalledWith null, { b : 12 }
     expect(callback).toHaveBeenCalledWith true, 'okay'
     expect(callback).toHaveBeenCalledWith /asd/, true
-    expect(callback).toHaveBeenCalledWith any(Function), 10
+    expect(callback).toHaveBeenCalledWith jasmine.any(Function), 10

--- a/tests/RedBlackTree.spec.coffee
+++ b/tests/RedBlackTree.spec.coffee
@@ -20,7 +20,7 @@ fill = (rbt) ->
   rbt.add 7
   rbt.add 13
 
-Queue = require('../').Queue
+Queue = require('../source').Queue
 validate = (rbt, treeStructure) ->
   validNodeIndex = 0
   treeQueue = new Queue([rbt._root])


### PR DESCRIPTION
call hasOwnProperty() on nodes to ignore properties or functions defined on Object
added task to Gruntfile.coffee to run the unit tests
updated the unit testing task to use grunt-jasmine-node - need to wait for the following PR to be merged before merging this one, though:
    https://github.com/jasmine-contrib/grunt-jasmine-node/pull/28
